### PR TITLE
add type file for development.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode
 .DS_Store
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ Currently the minimum necessary set for the functioning of ``SphericalPlot3D``, 
 - ``Polygon`` - fully supported
 - ``Line`` - supported
 
+## Development
+
+download the type file for three js.
+
+```bash
+npm i
+```
 
 License
 -------

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mathematica-threejs-graphics-engine",
+  "version": "0.0.1",
+  "description": "3D Graphics drawer for Mathematica based on Three.js =================== Written in JS parser and drawer allow to export or embed to web pages 3D graphics from Wolfram notebook.  Unlike other build-in export functions it recreates pure Mathematica's functions like ``Sphere[]``, ``GraphicsComplex[]``, ``Polygon[]`` and etc. See disscussion at https://mathematica.stackexchange.com/a/215025/53728.",
+  "main": "graphics3d.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JerryI/Mathematica-ThreeJS-graphics-engine.git"
+  },
+  "author": "Kirill Vasin",
+  "license": "GPL",
+  "bugs": {
+    "url": "https://github.com/JerryI/Mathematica-ThreeJS-graphics-engine/issues"
+  },
+  "homepage": "https://github.com/JerryI/Mathematica-ThreeJS-graphics-engine#readme",
+  "devDependencies": {
+    "@types/three": "^0.125.0"
+  }
+}


### PR DESCRIPTION
I find that developing js with a library like threejs but with no type file is terrible.

but since r116 is too old, from [here](https://www.npmjs.com/package/@types/three?activeTab=versions) I can only find 0.125.0, the nearest one.

so I add it. Now the js file has proper type hints.

![image](https://user-images.githubusercontent.com/30024051/212735675-73bd0eae-356a-412b-8115-aa378ff2446a.png)

(Although has some breaking [changes](https://github.com/mrdoob/three.js/wiki/Migration-Guide), it seems that no big deal). Since it won't affect the code.
